### PR TITLE
feat: simple pokemon models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Build files
 *.g.dart
+*.freezed.dart
 
 # Miscellaneous
 *.class

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -9,6 +9,7 @@ analyzer:
     - custom_lint
   exclude:
     - "**/*.g.dart"
+    - "**/*.freezed.dart"
   errors:
     invalid_annotation_target: ignore
 

--- a/build.yaml
+++ b/build.yaml
@@ -8,3 +8,21 @@ targets:
             - lib
           include:
             - lib/providers/*
+
+      json_serializable:
+        options:
+          explicit_to_json: true
+        generate_for:
+          exclude:
+            - lib
+          include:
+            - lib/apis/model/*
+
+      freezed:
+        enabled: true
+        generate_for:
+          exclude:
+            - lib
+          include:
+            - lib/apis/model/*
+            - lib/model/dto/*

--- a/lib/apis/model/simple_pokemon.dart
+++ b/lib/apis/model/simple_pokemon.dart
@@ -1,0 +1,15 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:pokedex_flutter_riverpod/utils/typedef.dart';
+
+part 'simple_pokemon.freezed.dart';
+part 'simple_pokemon.g.dart';
+
+@freezed
+class SimplePokemon with _$SimplePokemon {
+  const factory SimplePokemon({
+    @JsonKey(name: 'name') String? name,
+    @JsonKey(name: 'url') String? detailsUrl,
+  }) = _SimplePokemon;
+
+  factory SimplePokemon.fromJson(Json json) => _$SimplePokemonFromJson(json);
+}

--- a/lib/apis/model/simple_pokemon_list.dart
+++ b/lib/apis/model/simple_pokemon_list.dart
@@ -1,0 +1,18 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:pokedex_flutter_riverpod/apis/model/simple_pokemon.dart';
+import 'package:pokedex_flutter_riverpod/utils/typedef.dart';
+
+part 'simple_pokemon_list.freezed.dart';
+part 'simple_pokemon_list.g.dart';
+
+@freezed
+class SimplePokemonList with _$SimplePokemonList {
+  const factory SimplePokemonList({
+    @JsonKey(name: 'count') int? count,
+    @JsonKey(name: 'next') String? next,
+    @JsonKey(name: 'previous') String? previous,
+    @JsonKey(name: 'results') List<SimplePokemon>? simplePokemonList,
+  }) = _SimplePokemonList;
+
+  factory SimplePokemonList.fromJson(Json json) => _$SimplePokemonListFromJson(json);
+}

--- a/lib/extensions/simple_pokemon_ext.dart
+++ b/lib/extensions/simple_pokemon_ext.dart
@@ -1,0 +1,6 @@
+import 'package:pokedex_flutter_riverpod/apis/model/simple_pokemon.dart';
+import 'package:pokedex_flutter_riverpod/model/dto/simple_pokemon_dto.dart';
+
+extension SimplePokemonExt on SimplePokemon {
+  SimplePokemonDto toDto() => SimplePokemonDto(detailsUrl: detailsUrl ?? '');
+}

--- a/lib/extensions/simple_pokemon_list_ext.dart
+++ b/lib/extensions/simple_pokemon_list_ext.dart
@@ -1,0 +1,10 @@
+import 'package:pokedex_flutter_riverpod/apis/model/simple_pokemon_list.dart';
+import 'package:pokedex_flutter_riverpod/extensions/simple_pokemon_ext.dart';
+import 'package:pokedex_flutter_riverpod/model/dto/simple_pokemon_list_dto.dart';
+
+extension SimplePokemonListExt on SimplePokemonList {
+  SimplePokemonListDto toDto() => SimplePokemonListDto(
+        next: next ?? '',
+        simplePokemonList: [...?simplePokemonList?.map((simplePokemonList) => simplePokemonList.toDto())],
+      );
+}

--- a/lib/model/dto/simple_pokemon_dto.dart
+++ b/lib/model/dto/simple_pokemon_dto.dart
@@ -1,0 +1,10 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'simple_pokemon_dto.freezed.dart';
+
+@freezed
+class SimplePokemonDto with _$SimplePokemonDto {
+  const factory SimplePokemonDto({
+    @Default('') String detailsUrl,
+  }) = _SimplePokemonDto;
+}

--- a/lib/model/dto/simple_pokemon_list_dto.dart
+++ b/lib/model/dto/simple_pokemon_list_dto.dart
@@ -1,0 +1,12 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:pokedex_flutter_riverpod/model/dto/simple_pokemon_dto.dart';
+
+part 'simple_pokemon_list_dto.freezed.dart';
+
+@freezed
+class SimplePokemonListDto with _$SimplePokemonListDto {
+  const factory SimplePokemonListDto({
+    @Default('') String next,
+    @Default(<SimplePokemonDto>[]) List<SimplePokemonDto> simplePokemonList,
+  }) = _SimplePokemonListDto;
+}

--- a/lib/utils/typedef.dart
+++ b/lib/utils/typedef.dart
@@ -1,0 +1,1 @@
+typedef Json = Map<String, dynamic>;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -309,6 +309,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  freezed:
+    dependency: "direct main"
+    description:
+      name: freezed
+      sha256: "44c19278dd9d89292cf46e97dc0c1e52ce03275f40a97c5a348e802a924bf40e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.7"
   freezed_annotation:
     dependency: transitive
     description:
@@ -390,13 +398,21 @@ packages:
     source: hosted
     version: "0.7.1"
   json_annotation:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: json_annotation
       sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
       url: "https://pub.dev"
     source: hosted
     version: "4.9.0"
+  json_serializable:
+    dependency: "direct dev"
+    description:
+      name: json_serializable
+      sha256: ea1432d167339ea9b5bb153f0571d0039607a873d6e04e0117af043f14a1fd4b
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.8.0"
   leak_tracker:
     dependency: transitive
     description:
@@ -690,6 +706,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
+  source_helper:
+    dependency: transitive
+    description:
+      name: source_helper
+      sha256: "6adebc0006c37dd63fe05bca0a929b99f06402fc95aa35bf36d67f5c06de01fd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.4"
   source_span:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,9 @@ dependencies:
   cupertino_icons: ^1.0.8
   dartx: ^1.2.0
   flutter_riverpod: ^2.6.1
+  freezed: ^2.5.7
   go_router: ^14.3.0
+  json_annotation: ^4.9.0
   riverpod_annotation: ^2.6.1
   shared_preferences: ^2.3.2
 
@@ -22,6 +24,7 @@ dev_dependencies:
   build_runner: ^2.4.13
   custom_lint: ^0.7.0
   flutter_lints: ^5.0.0
+  json_serializable: ^6.8.0
   riverpod_generator: ^2.6.2
   riverpod_lint: ^2.6.2
 


### PR DESCRIPTION
- add freezed and json packages
- add json serializable and freezed entries in build yaml
- ignore freezed files in gitignore and analysis options
- add json typedef
- create api and dto models for simple pokemon and respective conversion extensions