### PR TITLE
feat: pokemon info ui

### DIFF
--- a/lib/classes/pokemon_color_picker.dart
+++ b/lib/classes/pokemon_color_picker.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:pokedex_flutter_riverpod/utils/const.dart';
 
 class PokemonColorPicker {
   static Color getColor(String type) => switch (type) {
@@ -22,4 +23,11 @@ class PokemonColorPicker {
         'fairy' => const Color(0xffD685AD),
         _ => const Color(0xffffffff),
       };
+
+  static Color typeDecorationColor(Color color, {bool isDarkened = false}) {
+    final hsl = HSLColor.fromColor(color);
+    final hslLight = hsl.withLightness(hsl.lightness + (isDarkened ? -colorModifier : colorModifier));
+
+    return hslLight.toColor();
+  }
 }

--- a/lib/extensions/pokemon_ext.dart
+++ b/lib/extensions/pokemon_ext.dart
@@ -11,6 +11,7 @@ import 'package:pokedex_flutter_riverpod/extensions/pokemon_type_ext.dart';
 import 'package:pokedex_flutter_riverpod/model/dto/pokemon_info_dto.dart';
 import 'package:pokedex_flutter_riverpod/model/dto/pokemon_dto.dart';
 import 'package:pokedex_flutter_riverpod/model/dto/pokemon_sprites_dto.dart';
+import 'package:pokedex_flutter_riverpod/utils/const.dart';
 
 extension PokemonExt on Pokemon {
   PokemonDto toDto() => PokemonDto(
@@ -34,4 +35,6 @@ extension PokemonDtoExt on PokemonDto {
   String get primaryTypeName => typeList.firstOrNull?.name ?? '';
 
   String get capitalizedNamed => name.capitalize();
+
+  String formatId() => '#${id.toString().padLeft(idNumberPadWidth, '0')}';
 }

--- a/lib/feature/pokemon_info/pokemon_info_page.dart
+++ b/lib/feature/pokemon_info/pokemon_info_page.dart
@@ -1,8 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:pokedex_flutter_riverpod/classes/pokemon_color_picker.dart';
 import 'package:pokedex_flutter_riverpod/extensions/pokemon_ext.dart';
 import 'package:pokedex_flutter_riverpod/feature/pokemon_info/info_scaffold.dart';
 import 'package:pokedex_flutter_riverpod/providers/selected_pokemon_provider.dart';
+import 'package:pokedex_flutter_riverpod/utils/const.dart';
+import 'package:pokedex_flutter_riverpod/utils/extension.dart';
+import 'package:pokedex_flutter_riverpod/utils/strings.dart';
+import 'package:pokedex_flutter_riverpod/widgets/pokemon_image.dart';
+import 'package:pokedex_flutter_riverpod/widgets/pokemon_type_list.dart';
 
 class PokemonInfoPage extends ConsumerWidget {
   const PokemonInfoPage({super.key});
@@ -11,9 +17,77 @@ class PokemonInfoPage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final selectedPokemon = ref.read(selectedPokemonProvider);
+    final primaryColor = selectedPokemon.primaryColor;
+    final textTheme = context.textTheme;
+    final themeData = context.themeData;
+    final typeDecorationColor = PokemonColorPicker.typeDecorationColor(primaryColor, isDarkened: true);
+
     return InfoScaffold(
-      color: ref.read(selectedPokemonProvider).primaryColor,
-      children: const [],
+      color: primaryColor,
+      children: [
+        Padding(
+          padding: infoPageHeaderPadding,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                selectedPokemon.capitalizedNamed,
+                style: textTheme.displayLarge,
+              ),
+              Align(
+                alignment: Alignment.centerRight,
+                child: Text(
+                  selectedPokemon.formatId(),
+                  style: textTheme.displaySmall,
+                ),
+              ),
+              PokemonTypeList(
+                pokemon: selectedPokemon,
+                isDecorationShown: true,
+              ),
+              Expanded(
+                flex: context.isPortrait ? 0 : 1,
+                child: PokemonImage(
+                  pokemon: selectedPokemon,
+                  size: infoPageImageSize,
+                ),
+              ),
+            ],
+          ),
+        ),
+        Expanded(
+          child: Container(
+            padding: infoPageModalPadding,
+            decoration: BoxDecoration(
+              color: themeData.primaryColor,
+              borderRadius: infoPageModalRadius,
+            ),
+            child: DefaultTabController(
+              length: tabLabels.length,
+              child: Column(
+                children: [
+                  TabBar(
+                    labelColor: typeDecorationColor,
+                    indicatorColor: typeDecorationColor,
+                    unselectedLabelColor: themeData.unselectedWidgetColor,
+                    tabs: tabLabels.map((tabLabel) => Tab(text: tabLabel)).toList(),
+                  ),
+                  const Expanded(
+                    child: TabBarView(
+                      children: [
+                        SizedBox(),
+                        SizedBox(),
+                        SizedBox(),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/utils/const.dart
+++ b/lib/utils/const.dart
@@ -11,3 +11,12 @@ const pokemonTypeNamePadding = EdgeInsets.symmetric(vertical: 4.0, horizontal: 1
 const pokemonTypeNameMargin = EdgeInsets.only(bottom: 4.0, right: 8.0);
 const progressIndicatorFooterPadding = EdgeInsets.all(12.0);
 const debouncerDelayInMilliseconds = 300;
+
+// Pokemon Info Page
+const infoPageHeaderPadding = EdgeInsets.symmetric(vertical: 8.0, horizontal: 16.0);
+const idNumberPadWidth = 3;
+const infoPageImageSize = 200.0;
+const colorModifier = 0.1;
+const typeNameRadius = 20.0;
+const infoPageModalPadding = EdgeInsets.symmetric(horizontal: 4.0);
+const infoPageModalRadius = BorderRadius.vertical(top: Radius.circular(20.0));

--- a/lib/utils/strings.dart
+++ b/lib/utils/strings.dart
@@ -9,3 +9,6 @@ const searchFieldHintText = 'Search Pokemon';
 
 // Loading Keys
 const getMorePokemonKey = 'get-more-pokemon';
+
+// Pokemon Info Page
+const tabLabels = ['About', 'Evolution', 'Moves'];

--- a/lib/widgets/pokemon_type_list.dart
+++ b/lib/widgets/pokemon_type_list.dart
@@ -1,5 +1,6 @@
 import 'package:dartx/dartx.dart';
 import 'package:flutter/material.dart';
+import 'package:pokedex_flutter_riverpod/classes/pokemon_color_picker.dart';
 import 'package:pokedex_flutter_riverpod/extensions/pokemon_ext.dart';
 import 'package:pokedex_flutter_riverpod/extensions/pokemon_type_ext.dart';
 import 'package:pokedex_flutter_riverpod/model/dto/pokemon_dto.dart';
@@ -8,20 +9,35 @@ import 'package:pokedex_flutter_riverpod/widgets/pokemon_type_name.dart';
 class PokemonTypeList extends StatelessWidget {
   const PokemonTypeList({
     required this.pokemon,
+    this.isDecorationShown = false,
     super.key,
   });
 
   final PokemonDto pokemon;
+  final bool isDecorationShown;
 
   @override
   Widget build(BuildContext context) {
+    final primaryTypeName = pokemon.primaryTypeName;
+    final primaryColor = isDecorationShown ? PokemonColorPicker.getColor(primaryTypeName) : null;
     final typeList = pokemon.typeList;
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        PokemonTypeName(name: pokemon.primaryTypeName),
-        if (typeList.length > 1) PokemonTypeName(name: typeList.second.name),
-      ],
-    );
+    final children = [
+      PokemonTypeName(
+        name: primaryTypeName,
+        primaryColor: primaryColor,
+      ),
+      if (typeList.length > 1)
+        PokemonTypeName(
+          name: typeList.second.name,
+          primaryColor: primaryColor,
+        ),
+    ];
+
+    return isDecorationShown
+        ? Row(children: children)
+        : Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: children,
+          );
   }
 }

--- a/lib/widgets/pokemon_type_name.dart
+++ b/lib/widgets/pokemon_type_name.dart
@@ -1,21 +1,30 @@
 import 'package:dartx/dartx.dart';
 import 'package:flutter/material.dart';
+import 'package:pokedex_flutter_riverpod/classes/pokemon_color_picker.dart';
 import 'package:pokedex_flutter_riverpod/utils/const.dart';
 import 'package:pokedex_flutter_riverpod/utils/extension.dart';
 
 class PokemonTypeName extends StatelessWidget {
   const PokemonTypeName({
     required this.name,
+    this.primaryColor,
     super.key,
   });
 
   final String name;
+  final Color? primaryColor;
 
   @override
   Widget build(BuildContext context) {
     return Container(
       padding: pokemonTypeNamePadding,
       margin: pokemonTypeNameMargin,
+      decoration: primaryColor == null
+          ? null
+          : BoxDecoration(
+              color: PokemonColorPicker.typeDecorationColor(primaryColor!),
+              borderRadius: BorderRadius.circular(typeNameRadius),
+            ),
       child: Text(
         name.capitalize(),
         style: context.textTheme.headlineMedium,


### PR DESCRIPTION
- add primary color parameter in pokemon type name
- set decoration in pokemon type name if has primary color
- add is decoration shown parameter in pokemon type list and use row if true
- add consts and strings
- add format id method in pokemon dto extension
- add type decoration color method in pokemon color picker
- add name, id, pokemon type list, image, and initial modal in pokemon info page