### PR TITLE
chore: followed by

### DIFF
--- a/lib/providers/pokemon_list_provider.dart
+++ b/lib/providers/pokemon_list_provider.dart
@@ -36,7 +36,7 @@ class PokemonList extends _$PokemonList {
     final simplePokemonList = ref.read(simplePokemonListProvider).simplePokemonList;
     final receivedPokemonList = await ref.read(pokemonApiProvider).getPokemonList(simplePokemonList: simplePokemonList);
 
-    state = AsyncValue.data([...?state.value, ...receivedPokemonList]);
+    state = AsyncValue.data([...?state.value?.followedBy(receivedPokemonList)]);
 
     ref.read(loadingProvider.notifier).clear();
   }


### PR DESCRIPTION
- use followed by instead of spread operator when getting more pokemon in pokemon list provider