### PR TITLE
fix: ios material

### DIFF
--- a/lib/feature/pokemon_info/pokemon_info_page.dart
+++ b/lib/feature/pokemon_info/pokemon_info_page.dart
@@ -62,7 +62,10 @@ class PokemonInfoPage extends ConsumerWidget {
             ),
             child: DefaultTabController(
               length: tabLabels.length,
-              child: const InfoTabBody(),
+              child: const Material(
+                color: Colors.transparent,
+                child: InfoTabBody(),
+              ),
             ),
           ),
         ),

--- a/lib/feature/pokemon_list/widgets/theme_choice_dialog.dart
+++ b/lib/feature/pokemon_list/widgets/theme_choice_dialog.dart
@@ -16,18 +16,21 @@ class ThemeChoiceDialog extends StatelessWidget {
   Widget build(BuildContext context) {
     return AlertDialog.adaptive(
       title: const Text(chooseThemeMenuLabel),
-      content: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: ThemeMode.values.map(
-          (themeMode) {
-            return RadioListTile(
-              title: Text(themeMode.name.capitalize()),
-              value: themeMode,
-              groupValue: savedThemeMode,
-              onChanged: onSelectTheme,
-            );
-          },
-        ).toList(),
+      content: Material(
+        color: Colors.transparent,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: ThemeMode.values.map(
+            (themeMode) {
+              return RadioListTile.adaptive(
+                title: Text(themeMode.name.capitalize()),
+                value: themeMode,
+                groupValue: savedThemeMode,
+                onChanged: onSelectTheme,
+              );
+            },
+          ).toList(),
+        ),
       ),
     );
   }


### PR DESCRIPTION
- wrap theme choice dialog and pokemon info page default tab controller with material and transparent color